### PR TITLE
Correct Last Commit badge URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ ght%2Ftest?label=Playwright&logo=playwright&logoColor=white&color=45ba4b)](https
  [![License](https://img.shields.io/github/license/yousufwaqar/playwright-automation-framework?color=yellow)](./LICENSE)
  [![Tests](https://img.shields.io/badge/UI%20%2B%20API-Covered-success)](#test-coverage)
  [![PRs Welcome](https://img.shields.io/badge/PRs-Welcome-brightgreen.svg)](./CONTRIBUTING.md)
- [![Last Commit](https://img.shields.io/github/last-commit/yousufwaqar/playwright-automation-framework?color=blue)](https://github.com
-/yousufwaqar/playwright-automation-framework/commits/main)
+ [![Last Commit](https://img.shields.io/github/last-commit/yousufwaqar/playwright-automation-framework?color=blue)](https://github.com/yousufwaqar/playwright-automation-framework/commits/main)
 
 <p>
   <a href="#why-this-framework">Why this framework?</a> |


### PR DESCRIPTION
Fixed the URL in the Last Commit badge link.

## Summary

<!-- What does this PR change and why? -->

## Type of change

- [ ] New test(s)
- [ ] New page object / fixture
- [ ] Bug fix
- [ ] Docs only
- [ ] CI / tooling
- [ ] Refactor (no behavior change)

## Checklist

- [ ] Branch name follows convention (`feat/`, `fix/`, `docs/`, `chore/`, `refactor/`)
- [ ] Commits use Conventional Commits
- [ ] `npm run test` passes locally
- [ ] New tests are tagged (`@smoke` / `@regression` / `@api` / `@external` / etc.)
- [ ] No raw selectors in spec files (use page objects)
- [ ] No hardcoded URLs or credentials (use `tests/test-data/`)
- [ ] README / docs updated if behavior or structure changed

## Screenshots / traces

<!-- Optional: attach screenshots, trace links, or HTML report excerpts -->

## Related issues

Closes #
