### PR TITLE
ci: disable firefox and webkit, only run chromium

### DIFF
--- a/.github/workflows/playwright-ci.yml
+++ b/.github/workflows/playwright-ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project: [chromium, firefox, webkit]
+        project: [chromium]
 
     steps:
       - name: Checkout code
@@ -46,6 +46,7 @@ jobs:
         env:
           CI: true
           BASE_URL: http://localhost:3000
+          API_BASE_URL: http://localhost:3000/api/v1
           TEST_ENV: ci
           API_TOKEN: mock-jwt-token-12345
           NODE_OPTIONS: "--import tsx"


### PR DESCRIPTION
## Summary

<!-- What does this PR change and why? -->

## Type of change

- [ ] New test(s)
- [ ] New page object / fixture
- [ ] Bug fix
- [ ] Docs only
- [ ] CI / tooling
- [ ] Refactor (no behavior change)

## Checklist

- [ ] Branch name follows convention (`feat/`, `fix/`, `docs/`, `chore/`, `refactor/`)
- [ ] Commits use Conventional Commits
- [ ] `npm run test` passes locally
- [ ] New tests are tagged (`@smoke` / `@regression` / `@api` / `@external` / etc.)
- [ ] No raw selectors in spec files (use page objects)
- [ ] No hardcoded URLs or credentials (use `tests/test-data/`)
- [ ] README / docs updated if behavior or structure changed

## Screenshots / traces

<!-- Optional: attach screenshots, trace links, or HTML report excerpts -->

## Related issues

Closes #
