### PR TITLE
chore: bump Playwright to 1.60.0

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -47,7 +47,7 @@ jobs:
   functional:
     name: Functional & API
     runs-on: ubuntu-latest
-    container: mcr.microsoft.com/playwright:v1.59.1-jammy
+    container: mcr.microsoft.com/playwright:v1.60.0-jammy
     steps:
       - uses: actions/checkout@v6
       - run: npm ci
@@ -63,7 +63,7 @@ jobs:
   accessibility:
     name: Accessibility (a11y)
     runs-on: ubuntu-latest
-    container: mcr.microsoft.com/playwright:v1.59.1-jammy
+    container: mcr.microsoft.com/playwright:v1.60.0-jammy
     steps:
       - uses: actions/checkout@v6
       - run: npm ci
@@ -79,7 +79,7 @@ jobs:
   security:
     name: API & HTTP Security
     runs-on: ubuntu-latest
-    container: mcr.microsoft.com/playwright:v1.59.1-jammy
+    container: mcr.microsoft.com/playwright:v1.60.0-jammy
     steps:
       - uses: actions/checkout@v6
       - run: npm ci
@@ -97,7 +97,7 @@ jobs:
   performance:
     name: Performance Smoke (non-blocking)
     runs-on: ubuntu-latest
-    container: mcr.microsoft.com/playwright:v1.59.1-jammy
+    container: mcr.microsoft.com/playwright:v1.60.0-jammy
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
@@ -108,7 +108,7 @@ jobs:
   visual:
     name: Visual Regression (non-blocking)
     runs-on: ubuntu-latest
-    container: mcr.microsoft.com/playwright:v1.59.1-jammy
+    container: mcr.microsoft.com/playwright:v1.60.0-jammy
     # Non-blocking until Linux baselines are generated via the
     # "Update Visual Baselines" workflow (visual-baseline.yml).
     continue-on-error: true

--- a/.github/workflows/visual-baseline.yml
+++ b/.github/workflows/visual-baseline.yml
@@ -16,7 +16,7 @@ jobs:
   update-baselines:
     name: Generate & commit Linux baselines
     runs-on: ubuntu-latest
-    container: mcr.microsoft.com/playwright:v1.59.1-jammy
+    container: mcr.microsoft.com/playwright:v1.60.0-jammy
     env:
       CI: "true"
       BASE_URL: http://localhost:3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 #
 # Uses the official Playwright image (free), which ships the matching browser
 # binaries and OS dependencies, so no `playwright install` step is needed. The
-# image tag is pinned to the Playwright version in package.json (1.59.1).
-FROM mcr.microsoft.com/playwright:v1.59.1-jammy
+# image tag is pinned to the Playwright version in package.json (1.60.0).
+FROM mcr.microsoft.com/playwright:v1.60.0-jammy
 
 WORKDIR /app
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "playwright-automation-framework",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright-automation-framework",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "devDependencies": {
         "@axe-core/playwright": "^4.11.3",
-        "@playwright/test": "^1.45.0",
+        "@playwright/test": "^1.60.0",
         "@types/node": "^25.9.1",
         "allure-commandline": "^2.42.0",
         "allure-playwright": "^3.9.0",
@@ -479,13 +479,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -729,13 +729,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -748,9 +748,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-automation-framework",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Enterprise-grade Playwright + TypeScript test automation framework with POM, parallel execution, and CI/CD integration",
   "author": "Yousuf Waqar <yousufwaqar7@gmail.com>",
   "license": "MIT",
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3",
-    "@playwright/test": "^1.45.0",
+    "@playwright/test": "^1.60.0",
     "@types/node": "^25.9.1",
     "allure-commandline": "^2.42.0",
     "allure-playwright": "^3.9.0",


### PR DESCRIPTION
- @playwright/test ^1.45.0 -> ^1.60.0 (package.json + lockfile, public npm registry)
- Docker base image and CI containers v1.59.1-jammy -> v1.60.0-jammy
- Bump framework version 1.3.0 -> 1.3.1

Typecheck clean; 22 functional/a11y/security tests pass; visual baselines unchanged (renderer output byte-identical).

## Summary

<!-- What does this PR change and why? -->

## Type of change

- [ ] New test(s)
- [ ] New page object / fixture
- [ ] Bug fix
- [ ] Docs only
- [ ] CI / tooling
- [ ] Refactor (no behavior change)

## Checklist

- [ ] Branch name follows convention (`feat/`, `fix/`, `docs/`, `chore/`, `refactor/`)
- [ ] Commits use Conventional Commits
- [ ] `npm run test` passes locally
- [ ] New tests are tagged (`@smoke` / `@regression` / `@api` / `@external` / etc.)
- [ ] No raw selectors in spec files (use page objects)
- [ ] No hardcoded URLs or credentials (use `tests/test-data/`)
- [ ] README / docs updated if behavior or structure changed

## Screenshots / traces

<!-- Optional: attach screenshots, trace links, or HTML report excerpts -->

## Related issues

Closes #
