### PR TITLE
fix: wire up AI-SDET agent layer (analyzer, live loop, self-healing, …

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,10 +507,17 @@ To bridge the gap between static guidelines and active automation, this reposito
 - **Advanced Self-Healing Locators:** Embedded directly within `BasePage.ts`, elements support custom-designed opt-in **Self-Healing fallbacks**. If a primary locator times out, the engine scans secondary candidates (inner text, aria roles, button types), successfully fulfills the action to prevent flaky pipeline drops, and logs the healing patch to `test-results/healed_locators.json` for review.
 - **CI Triage & Remediation Summarizer:** A post-test CI analyzer (`scripts/ci-failure-analyzer.js`) runs in GitHub Actions to compile failed tests, traces, and source snippets into a beautiful Markdown dashboard under the GHA Job Summary with copy-paste remediation plans.
 
-To execute the CLI tool:
+**Setup (one-time)** — install the Python dependencies (Python 3.9+):
 ```bash
-python3 agent/cli.py
+npm run agent:install      # or: pip install -r agent/requirements.txt
 ```
+
+**Run the interactive CLI workbench:**
+```bash
+npm run agent              # or: python agent/cli.py   (use python3 on macOS/Linux)
+```
+Live LLM mode activates automatically when `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` is set (see [`.env.example`](.env.example)); otherwise the high-fidelity hybrid simulation engine runs with no keys required.
+
 To launch the Visual Dashboard, open [`agent_dashboard.html`](agent_dashboard.html) in your browser.
 
 ---
@@ -535,6 +542,8 @@ To launch the Visual Dashboard, open [`agent_dashboard.html`](agent_dashboard.ht
 | `npm run test:performance`  | Run performance smoke tests           |
 | `npm run test:visual`       | Run visual regression tests           |
 | `npm run test:visual:update`| Refresh visual baselines (current platform) |
+| `npm run test:unit`         | Run isolated unit tests (helpers/config) |
+| `npm run test:selfheal`     | Run self-healing locator recovery tests |
 | `npm run perf:k6`           | Run k6 API load script (requires k6)  |
 | `npm run typecheck`         | Type-check without emitting           |
 | `npm run lint`              | Lint with ESLint (typescript-eslint + playwright rules) |
@@ -543,6 +552,9 @@ To launch the Visual Dashboard, open [`agent_dashboard.html`](agent_dashboard.ht
 | `npm run test:theinternet`  | Run The Internet external suite       |
 | `npm run test:api:external` | Run RESTful Booker external API suite |
 | `npm run report`            | Open Playwright HTML report           |
+| `npm run agent:install`     | Install the Python AI SDET agent deps |
+| `npm run agent`             | Launch the interactive AI SDET agent CLI |
+| `npm run clean`             | Remove test-results/ and playwright-report/ |
 
 ---
 

--- a/agent/orchestrator.py
+++ b/agent/orchestrator.py
@@ -17,6 +17,7 @@ class SDETAgentOrchestrator:
         self.anthropic_key = os.getenv("ANTHROPIC_API_KEY")
         self.is_live = bool(self.openai_key or self.anthropic_key)
         self.history: List[Dict[str, Any]] = []
+        self.max_iterations = int(os.getenv("AGENT_MAX_ITERATIONS", "10"))
 
     def run_task(self, task_description: str, scenario_id: str = None) -> Generator[Dict[str, Any], None, None]:
         """Runs the agent on a task. Yields status/step dictionaries for real-time reporting."""
@@ -72,30 +73,205 @@ Your output must be a structured loop of thoughts and tool calls.
         # To ensure the demo works beautifully, we fall back to simulation if the API call fails or keys are invalid.
         try:
             if self.openai_key:
-                from openai import OpenAI
-                client = OpenAI(api_key=self.openai_key)
-                model = "gpt-4o"
-                # Standard OpenAI structured tool call implementation
-                # ...
+                yield from self._run_openai_loop(task, system_prompt)
             elif self.anthropic_key:
-                import anthropic
-                client = anthropic.Anthropic(api_key=self.anthropic_key)
-                model = "claude-3-5-sonnet-20241022"
-                # Standard Anthropic tools implementation
-                # ...
+                yield from self._run_anthropic_loop(task, system_prompt)
+            else:
+                yield from self._run_simulation(task, None)
             
-            # Since we want to provide an absolutely rock-solid hybrid demo, let's fall back gracefully
-            # if we encounter any library or networking issues.
-            yield {
-                "type": "thought",
-                "text": "Live LLM engine configured. Executing task agent loop..."
-            }
+            # Live execution completed inside the provider loop above.
         except Exception as e:
             yield {
                 "type": "error",
-                "message": f"Error initializing live client: {e}. Falling back to simulation mode."
+                "message": f"Live LLM execution failed ({e}). Falling back to the simulation engine."
             }
-            yield from self._run_simulation(task, "fix_test")
+            yield from self._run_simulation(task, None)
+
+    def _execute_tool(self, name: str, args: Dict[str, Any]) -> str:
+        """Dispatch a single tool call to the sandboxed tools module and return a string result."""
+        try:
+            if name == "list_files":
+                return json.dumps(tools.list_files())
+            if name == "read_file":
+                return tools.read_file(args["file_path"])
+            if name == "write_file":
+                return tools.write_file(args["file_path"], args.get("content", ""))
+            if name == "edit_file_patch":
+                return tools.edit_file_patch(args["file_path"], args["search"], args["replace"])
+            if name == "run_command":
+                return json.dumps(tools.run_command(args["command"]))
+            return f"Error: unknown tool '{name}'."
+        except KeyError as missing:
+            return f"Error: missing required argument {missing} for tool '{name}'."
+        except Exception as exc:
+            return f"Error executing tool '{name}': {exc}"
+
+    def _tool_schemas(self) -> List[Dict[str, Any]]:
+        """Provider-agnostic JSON-schema description of every tool the agent may call."""
+        return [
+            {
+                "name": "list_files",
+                "description": "List every source file path in the repository.",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+            {
+                "name": "read_file",
+                "description": "Read the full UTF-8 contents of a repository file.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "file_path": {"type": "string", "description": "Path relative to the repo root."}
+                    },
+                    "required": ["file_path"],
+                },
+            },
+            {
+                "name": "write_file",
+                "description": "Create or overwrite a file with the given contents.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "file_path": {"type": "string"},
+                        "content": {"type": "string"},
+                    },
+                    "required": ["file_path", "content"],
+                },
+            },
+            {
+                "name": "edit_file_patch",
+                "description": "Replace the first occurrence of `search` with `replace` inside a file.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "file_path": {"type": "string"},
+                        "search": {"type": "string"},
+                        "replace": {"type": "string"},
+                    },
+                    "required": ["file_path", "search", "replace"],
+                },
+            },
+            {
+                "name": "run_command",
+                "description": "Run an allow-listed command (npm, npx, git, node) and return exit_code/stdout/stderr.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {"type": "string", "description": "The full command line to execute."}
+                    },
+                    "required": ["command"],
+                },
+            },
+        ]
+
+    def _openai_tool_specs(self) -> List[Dict[str, Any]]:
+        return [{"type": "function", "function": schema} for schema in self._tool_schemas()]
+
+    def _anthropic_tool_specs(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "name": schema["name"],
+                "description": schema["description"],
+                "input_schema": schema["parameters"],
+            }
+            for schema in self._tool_schemas()
+        ]
+
+    def _run_openai_loop(self, task: str, system_prompt: str) -> Generator[Dict[str, Any], None, None]:
+        """Drive a tool-using ReAct loop against the OpenAI Chat Completions API."""
+        from openai import OpenAI
+
+        client = OpenAI(api_key=self.openai_key)
+        model = os.getenv("OPENAI_MODEL", "gpt-4o")
+        tool_specs = self._openai_tool_specs()
+        messages: List[Any] = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": task},
+        ]
+
+        yield {"type": "thought", "text": f"Live OpenAI engine ready ({model}). Entering ReAct loop..."}
+
+        for _ in range(self.max_iterations):
+            response = client.chat.completions.create(
+                model=model,
+                messages=messages,
+                tools=tool_specs,
+                tool_choice="auto",
+            )
+            message = response.choices[0].message
+            messages.append(message)
+
+            if message.content:
+                yield {"type": "thought", "text": message.content}
+
+            tool_calls = message.tool_calls or []
+            if not tool_calls:
+                yield {"type": "summary", "message": message.content or "Task complete."}
+                return
+
+            for call in tool_calls:
+                name = call.function.name
+                try:
+                    args = json.loads(call.function.arguments or "{}")
+                except json.JSONDecodeError:
+                    args = {}
+                yield {"type": "tool_call", "tool": name, "arguments": args}
+                output = self._execute_tool(name, args)
+                yield {"type": "tool_result", "tool": name, "output": output}
+                messages.append({
+                    "role": "tool",
+                    "tool_call_id": call.id,
+                    "content": output,
+                })
+
+        yield {"type": "summary", "message": f"Reached the maximum of {self.max_iterations} iterations."}
+
+    def _run_anthropic_loop(self, task: str, system_prompt: str) -> Generator[Dict[str, Any], None, None]:
+        """Drive a tool-using ReAct loop against the Anthropic Messages API."""
+        import anthropic
+
+        client = anthropic.Anthropic(api_key=self.anthropic_key)
+        model = os.getenv("ANTHROPIC_MODEL", "claude-3-5-sonnet-20241022")
+        tool_specs = self._anthropic_tool_specs()
+        messages: List[Any] = [{"role": "user", "content": task}]
+
+        yield {"type": "thought", "text": f"Live Anthropic engine ready ({model}). Entering ReAct loop..."}
+
+        for _ in range(self.max_iterations):
+            response = client.messages.create(
+                model=model,
+                max_tokens=4096,
+                system=system_prompt,
+                tools=tool_specs,
+                messages=messages,
+            )
+
+            tool_results = []
+            for block in response.content:
+                if block.type == "text":
+                    yield {"type": "thought", "text": block.text}
+                elif block.type == "tool_use":
+                    yield {"type": "tool_call", "tool": block.name, "arguments": block.input}
+                    output = self._execute_tool(block.name, block.input or {})
+                    yield {"type": "tool_result", "tool": block.name, "output": output}
+                    tool_result = {
+                        "type": "tool_result",
+                        "tool_use_id": block.id,
+                        "content": output,
+                    }
+                    if output.startswith("Error"):
+                        tool_result["is_error"] = True
+                    tool_results.append(tool_result)
+
+            messages.append({"role": "assistant", "content": response.content})
+
+            if response.stop_reason != "tool_use":
+                final_text = "".join(b.text for b in response.content if b.type == "text")
+                yield {"type": "summary", "message": final_text or "Task complete."}
+                return
+
+            messages.append({"role": "user", "content": tool_results})
+
+        yield {"type": "summary", "message": f"Reached the maximum of {self.max_iterations} iterations."}
 
     def _run_simulation(self, task: str, scenario_id: str) -> Generator[Dict[str, Any], None, None]:
         """Runs high-fidelity simulations that perform REAL file edits, command execution, and test runs!"""

--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -1,0 +1,10 @@
+# Python dependencies for the AI SDET Agent workbench (agent/cli.py).
+# Install with: npm run agent:install   (or: pip install -r agent/requirements.txt)
+#
+# rich + python-dotenv are required for the CLI and simulation engine.
+# openai / anthropic are only needed for live LLM mode (set the matching API key
+# in your environment or .env); the simulation engine runs without them.
+rich>=13.7.0
+python-dotenv>=1.0.0
+openai>=1.40.0
+anthropic>=0.34.0

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:theinternet": "cross-env NODE_OPTIONS=\"--import tsx\" npx playwright test --project=chromium --grep @theinternet",
     "test:api:external": "cross-env NODE_OPTIONS=\"--import tsx\" npx playwright test --project=chromium tests/external/api/",
     "test:unit": "cross-env NODE_OPTIONS=\"--import tsx\" npx playwright test --config=playwright.unit.config.ts",
+    "test:selfheal": "cross-env NODE_OPTIONS=\"--import tsx\" npx playwright test --project=chromium --grep @selfheal",
     "perf:k6": "k6 run performance/k6/api-load.js",
     "report": "npx playwright show-report",
     "allure:generate": "allure generate allure-results --clean -o allure-report",
@@ -35,7 +36,9 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit",
-    "clean": "node scripts/clean.js"
+    "clean": "node scripts/clean.js",
+    "agent": "python agent/cli.py",
+    "agent:install": "pip install -r agent/requirements.txt"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3",

--- a/scripts/ci-failure-analyzer.js
+++ b/scripts/ci-failure-analyzer.js
@@ -14,7 +14,7 @@ const path = require('path');
  * @author Yousuf Waqar & AI SDET Agent
  */
 
-const REPORT_PATH = path.join(process.cwd(), 'playwright-report', 'results.json');
+const REPORT_PATH = path.join(process.cwd(), 'test-results', 'results.json');
 const OUTPUT_SUMMARY_PATH = path.join(process.cwd(), 'test-results', 'ci-quality-summary.md');
 
 function main() {
@@ -39,16 +39,23 @@ function main() {
       report.suites.forEach(suite => parseSuite(suite, failures));
     }
 
-    totalTests = report.stats?.numTotalTests || 0;
-    failedTests = report.stats?.numFailedTests || 0;
-    passedTests = totalTests - failedTests;
+    // Playwright's JSON reporter exposes run totals under `stats`:
+    // expected = passed, unexpected = failed, plus flaky/skipped.
+    const stats = report.stats || {};
+    passedTests = stats.expected || 0;
+    failedTests = stats.unexpected || 0;
+    const flakyTests = stats.flaky || 0;
+    const skippedTests = stats.skipped || 0;
+    totalTests = passedTests + failedTests + flakyTests + skippedTests;
 
     let markdown = `# 📊 GITHUB ACTIONS CI QUALITY REPORT SUMMARY\n\n`;
     markdown += `| Metric | Count | Status |\n`;
     markdown += `| --- | --- | --- |\n`;
     markdown += `| **Total Tests** | ${totalTests} | 📋 |\n`;
     markdown += `| **Passed** | ${passedTests} | ${failedTests === 0 ? '✅ SUCCESS' : '⚠️ WARN'} |\n`;
-    markdown += `| **Failed** | ${failedTests} | ${failedTests === 0 ? '✅ ZERO FAILURES' : '❌ FAILURES DETECTED'} |\n\n`;
+    markdown += `| **Failed** | ${failedTests} | ${failedTests === 0 ? '✅ ZERO FAILURES' : '❌ FAILURES DETECTED'} |\n`;
+    markdown += `| **Flaky** | ${flakyTests} | ${flakyTests === 0 ? '✅ STABLE' : '⚠️ UNSTABLE'} |\n`;
+    markdown += `| **Skipped** | ${skippedTests} | ${skippedTests === 0 ? '—' : '⏭️ SKIPPED'} |\n\n`;
 
     if (failures.length > 0) {
       markdown += `## ❌ Detailed Failure Breakdown & Remediation Guides\n\n`;

--- a/tests/self-healing/self-healing.spec.ts
+++ b/tests/self-healing/self-healing.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from "../../src/fixtures/base.fixture";
+import { SelfHealingHelper } from "../../src/utils/SelfHealingHelper";
+import type { Logger } from "../../src/utils/Logger";
+import type { Page } from "@playwright/test";
+
+/**
+ * Self-Healing Locator Tests
+ *
+ * Exercises the SelfHealingHelper recovery path end-to-end against the mock app:
+ * a deliberately drifted primary selector should fail, then heal via a structural
+ * fallback so the action still completes. This keeps the self-healing engine wired
+ * to a real test (preventing it from rotting) while NOT masking critical-path
+ * regressions, because the fallback is explicit and the assertion still verifies
+ * the real outcome.
+ *
+ * @author Yousuf Waqar & AI SDET Agent
+ */
+
+test.describe("Self-Healing Locators @selfheal @regression", () => {
+  test.beforeEach(async ({ page }: { page: Page }) => {
+    await page.goto("/login");
+  });
+
+  test("fillWithHealing recovers when the primary selector has drifted", async ({
+    page,
+    logger,
+  }: {
+    page: Page;
+    logger: Logger;
+  }) => {
+    const driftedSelector = '[data-testid="email-input-DRIFTED"]';
+    const driftedLocator = page.locator(driftedSelector);
+
+    await SelfHealingHelper.fillWithHealing(
+      page,
+      driftedLocator,
+      driftedSelector,
+      ['[data-testid="email-input"]'],
+      "healed@example.com",
+      logger,
+      1500
+    );
+
+    await expect(page.locator('[data-testid="email-input"]')).toHaveValue(
+      "healed@example.com"
+    );
+  });
+
+  test("clickWithHealing recovers when the primary selector has drifted", async ({
+    page,
+    logger,
+  }: {
+    page: Page;
+    logger: Logger;
+  }) => {
+    await page.locator('[data-testid="email-input"]').fill("testuser@example.com");
+    await page
+      .locator('[data-testid="password-input"]')
+      .fill("SecurePassword123!");
+
+    const driftedSelector = '[data-testid="login-button-DRIFTED"]';
+    const driftedLocator = page.locator(driftedSelector);
+
+    await SelfHealingHelper.clickWithHealing(
+      page,
+      driftedLocator,
+      driftedSelector,
+      ['[data-testid="login-button"]'],
+      logger,
+      1500
+    );
+
+    await expect(page).toHaveURL(/\/dashboard/);
+  });
+});


### PR DESCRIPTION
…deps)

Fixes four issues in the AI-SDET agent layer:

- ci-failure-analyzer: read Playwright JSON from test-results/results.json (not playwright-report/) and compute counts from stats.expected/ unexpected/flaky/skipped instead of nonexistent numTotalTests/ numFailedTests; add Flaky and Skipped rows.
- agent: add requirements.txt and npm scripts (agent, agent:install, test:selfheal) plus README setup/run docs so the Python workbench is reproducible.
- orchestrator: replace the _run_live no-op stub with real tool-using ReAct loops for OpenAI and Anthropic (provider-agnostic tool schemas, _execute_tool dispatch, iteration cap via AGENT_MAX_ITERATIONS, and graceful fallback to the simulation engine on error).
- self-healing: add tests/self-healing/self-healing.spec.ts exercising fillWithHealing and clickWithHealing so the helper is covered without masking critical-path regressions.

## Summary

<!-- What does this PR change and why? -->

## Type of change

- [ ] New test(s)
- [ ] New page object / fixture
- [ ] Bug fix
- [ ] Docs only
- [ ] CI / tooling
- [ ] Refactor (no behavior change)

## Checklist

- [ ] Branch name follows convention (`feat/`, `fix/`, `docs/`, `chore/`, `refactor/`)
- [ ] Commits use Conventional Commits
- [ ] `npm run test` passes locally
- [ ] New tests are tagged (`@smoke` / `@regression` / `@api` / `@external` / etc.)
- [ ] No raw selectors in spec files (use page objects)
- [ ] No hardcoded URLs or credentials (use `tests/test-data/`)
- [ ] README / docs updated if behavior or structure changed

## Screenshots / traces

<!-- Optional: attach screenshots, trace links, or HTML report excerpts -->

## Related issues

Closes #
