### PR TITLE
ci: publish the Allure report live to GitHub Pages with trend history

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -16,10 +16,12 @@ on:
 permissions:
   contents: read
 
-# Cancel superseded runs on the same ref to save CI minutes.
+# Cancel superseded runs on the same ref to save CI minutes, but never cancel a
+# main run mid-flight: it may be deploying the Allure report to Pages and an
+# aborted deploy would drop accumulated trend history.
 concurrency:
   group: quality-gate-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   CI: "true"
@@ -214,6 +216,32 @@ jobs:
         with:
           name: allure-results
           path: allure-results
+      - name: Restore Allure history from the live Pages site
+        # On main, seed the new run with the previously published history so the
+        # generated report accumulates trend/retry/duration charts over time.
+        # First run 404s are ignored (|| true); Allure then bootstraps history.
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        run: |
+          mkdir -p allure-results/history
+          base="https://yousufwaqar.github.io/playwright-automation-framework/history"
+          for f in history.json history-trend.json duration-trend.json categories-trend.json retry-trend.json retries-trend.json; do
+            curl -fsSL "$base/$f" -o "allure-results/history/$f" || true
+          done
+      - name: Write Allure executor metadata
+        # Gives trend entries a build order, name and links back to this run.
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        run: |
+          cat > allure-results/executor.json <<EOF
+          {
+            "name": "GitHub Actions",
+            "type": "github",
+            "reportName": "${GITHUB_WORKFLOW} #${GITHUB_RUN_NUMBER}",
+            "buildOrder": ${GITHUB_RUN_NUMBER},
+            "buildName": "${GITHUB_WORKFLOW} #${GITHUB_RUN_NUMBER}",
+            "buildUrl": "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}",
+            "reportUrl": "https://yousufwaqar.github.io/playwright-automation-framework/"
+          }
+          EOF
       - name: Generate Allure HTML report
         run: npm run allure:generate
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -221,6 +249,43 @@ jobs:
           name: allure-report
           path: allure-report/
           retention-days: 14
+
+  publish-pages:
+    name: Publish Allure to Pages (non-blocking)
+    # Deploys the generated Allure report to GitHub Pages, but only for main
+    # pushes (not PRs or develop). `always()` keeps it eligible even though the
+    # upstream allure-report job is continue-on-error; a missing artifact just
+    # fails this job non-blockingly.
+    needs: [allure-report]
+    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    # Serialise Pages deploys so a newer run never aborts an in-flight deploy.
+    concurrency:
+      group: github-pages
+      cancel-in-progress: false
+    permissions:
+      actions: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Download generated Allure report
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: allure-report
+          path: allure-report
+      - name: Configure Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
+        with:
+          path: allure-report
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
 
   quality-gate:
     name: Quality Gate

--- a/README.md
+++ b/README.md
@@ -448,13 +448,17 @@ npm run allure:report
 ```
 
 In CI, the **Allure Report** job generates the report and publishes it as the
-downloadable `allure-report` artifact on each Quality Gate run.
+downloadable `allure-report` artifact on every Quality Gate run. On pushes to
+`main`, the **Publish Allure to Pages** job also deploys it as a live site with
+accumulating trend, duration and retry history:
+
+**📊 [View the live Allure report](https://yousufwaqar.github.io/playwright-automation-framework/)**
 
 <div align="center">
 
 <img src="docs/images/allure-report.png" alt="Allure report overview generated from the deterministic suite" width="760"/>
 
-<sub><em>Allure report overview (deterministic suite). Generated from <code>allure-results/</code> and published as the <code>allure-report</code> CI artifact.</em></sub>
+<sub><em>Allure report overview (deterministic suite). Generated from <code>allure-results/</code>, published as the <code>allure-report</code> CI artifact and deployed live to <a href="https://yousufwaqar.github.io/playwright-automation-framework/">GitHub Pages</a>.</em></sub>
 
 </div>
 
@@ -599,11 +603,10 @@ Recently delivered:
 - ✅ Composite Quality Gate CI with per-module status checks
 - ✅ ESLint (typescript-eslint + eslint-plugin-playwright) in CI
 - ✅ Repo-committed AI agent toolkit (AGENTS.md, prompt recipes, Copilot setup steps)
-- ✅ Allure reporting (results on every run; HTML report published as a CI artifact)
+- ✅ Allure reporting (results on every run; HTML report published as a CI artifact and a [live GitHub Pages site](https://yousufwaqar.github.io/playwright-automation-framework/) with trend history)
 
 Planned:
 
-- Publish Playwright HTML reports to GitHub Pages
 - Promote the visual job to blocking once Linux baselines are seeded
 - Add reusable GitHub Actions workflow templates
 


### PR DESCRIPTION
Add a dedicated publish-pages job that deploys the generated Allure report to GitHub Pages on main pushes. The allure-report job now restores the previously published history and writes executor metadata so trend, duration and retry charts accumulate across runs. Workflow concurrency no longer cancels in-flight main runs (which may be deploying), and the deploy is serialised on a github-pages group.

## Summary

<!-- What does this PR change and why? -->

## Type of change

- [ ] New test(s)
- [ ] New page object / fixture
- [ ] Bug fix
- [ ] Docs only
- [ ] CI / tooling
- [ ] Refactor (no behavior change)

## Checklist

- [ ] Branch name follows convention (`feat/`, `fix/`, `docs/`, `chore/`, `refactor/`)
- [ ] Commits use Conventional Commits
- [ ] `npm run test` passes locally
- [ ] New tests are tagged (`@smoke` / `@regression` / `@api` / `@external` / etc.)
- [ ] No raw selectors in spec files (use page objects)
- [ ] No hardcoded URLs or credentials (use `tests/test-data/`)
- [ ] README / docs updated if behavior or structure changed

## Screenshots / traces

<!-- Optional: attach screenshots, trace links, or HTML report excerpts -->

## Related issues

Closes #
