### PR TITLE
docs: use static MIT license badge and drop Codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,8 +4,8 @@ name: Coverage
 # (src/utils). The browser-coupled SelfHealingHelper is excluded in .c8rc.json
 # because its public API only orchestrates a live Page/Locator and is exercised
 # by the @selfheal integration suite, not the unit suite. The c8 threshold in
-# .c8rc.json fails this job if coverage regresses; the Codecov upload is
-# supplementary visualisation and is non-blocking.
+# .c8rc.json fails this job if coverage regresses. The full HTML/lcov report is
+# published as a downloadable CI artifact.
 
 on:
   push:
@@ -47,14 +47,3 @@ jobs:
           name: coverage
           path: coverage/
           retention-days: 14
-
-      - name: Upload to Codecov
-        if: always()
-        continue-on-error: true
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
-        with:
-          files: ./coverage/lcov.info
-          flags: unit
-          fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -7,11 +7,10 @@
 [![Quality Gate](https://github.com/yousufwaqar/playwright-automation-framework/actions/workflows/quality-gate.yml/badge.svg)](https://github.com/yousufwaqar/playwright-automation-framework/actions/workflows/quality-gate.yml)
 [![CodeQL](https://github.com/yousufwaqar/playwright-automation-framework/actions/workflows/codeql.yml/badge.svg)](https://github.com/yousufwaqar/playwright-automation-framework/actions/workflows/codeql.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/yousufwaqar/playwright-automation-framework/badge)](https://scorecard.dev/viewer/?uri=github.com/yousufwaqar/playwright-automation-framework)
-[![codecov](https://codecov.io/gh/yousufwaqar/playwright-automation-framework/graph/badge.svg)](https://codecov.io/gh/yousufwaqar/playwright-automation-framework)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.x-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Playwright](https://img.shields.io/badge/Playwright-1.60+-45ba4b?logo=playwright&logoColor=white)](https://playwright.dev/)
  [![Node.js](https://img.shields.io/badge/Node.js-20+-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org/)
- [![License](https://img.shields.io/github/license/yousufwaqar/playwright-automation-framework?color=yellow)](./LICENSE)
+ [![License](https://img.shields.io/badge/license-MIT-yellow.svg)](./LICENSE)
  [![Tests](https://img.shields.io/badge/UI%20%2B%20API-Covered-success)](#test-coverage)
  [![PRs Welcome](https://img.shields.io/badge/PRs-Welcome-brightgreen.svg)](./CONTRIBUTING.md)
  [![Last Commit](https://img.shields.io/github/last-commit/yousufwaqar/playwright-automation-framework?color=blue)](https://github.com/yousufwaqar/playwright-automation-framework/commits/main)
@@ -259,7 +258,7 @@ playwright-automation-framework/
 ├── .github/
 │   ├── workflows/
 │   │   ├── quality-gate.yml           # Authoritative CI: composite quality gate
-│   │   ├── coverage.yml               # Unit coverage (c8) + Codecov upload
+│   │   ├── coverage.yml               # Unit coverage (c8) + report artifact
 │   │   ├── codeql.yml                 # CodeQL SAST (JS/TS)
 │   │   ├── scorecard.yml              # OpenSSF Scorecard supply-chain score
 │   │   ├── dependency-review.yml      # Blocks PRs adding vulnerable deps


### PR DESCRIPTION
The license badge relied on shields.io's shared GitHub token pool and intermittently rendered an error; a static MIT badge removes that dependency. Codecov was never activated for the repo, so remove its badge and the orphaned non-blocking upload step (c8 already enforces the coverage threshold and the report ships as a CI artifact).

## Summary

<!-- What does this PR change and why? -->

## Type of change

- [ ] New test(s)
- [ ] New page object / fixture
- [ ] Bug fix
- [ ] Docs only
- [ ] CI / tooling
- [ ] Refactor (no behavior change)

## Checklist

- [ ] Branch name follows convention (`feat/`, `fix/`, `docs/`, `chore/`, `refactor/`)
- [ ] Commits use Conventional Commits
- [ ] `npm run test` passes locally
- [ ] New tests are tagged (`@smoke` / `@regression` / `@api` / `@external` / etc.)
- [ ] No raw selectors in spec files (use page objects)
- [ ] No hardcoded URLs or credentials (use `tests/test-data/`)
- [ ] README / docs updated if behavior or structure changed

## Screenshots / traces

<!-- Optional: attach screenshots, trace links, or HTML report excerpts -->

## Related issues

Closes #
